### PR TITLE
TINY-8050: Update moxiedoc to fail with a non-zero exit code if an error occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Improved
+- The CLI will now return a non-zero exit code if an error occurs. Warnings can also be configured to fail via the `--fail-on-warnings` option.

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -13,6 +13,7 @@ program
   .option('-v, --verbose', 'verbose output')
   .option('--debug', 'debug output')
   .option('--dry', 'dry run only syntax check')
+  .option('--fail-on-warning', 'fail if warnings are produced')
   .parse(process.argv);
 
 program.on('--help', () => {
@@ -29,4 +30,8 @@ if (!program.args.length) {
 const opts = program.opts() as MoxiedocSettings;
 opts.paths = program.args;
 
-moxieDocProcess(opts);
+const { errors, warnings } = moxieDocProcess(opts);
+
+if (errors > 0 || warnings > 0 && opts.failOnWarning) {
+  process.exit(1);
+}

--- a/src/lib/moxiedoc.ts
+++ b/src/lib/moxiedoc.ts
@@ -15,6 +15,12 @@ export interface MoxiedocSettings {
   debug?: boolean;
   paths: string[];
   dry?: boolean;
+  failOnWarning?: boolean;
+}
+
+export interface MoxiedocResult {
+  errors: number;
+  warnings: number;
 }
 
 /**
@@ -34,7 +40,7 @@ export interface MoxiedocSettings {
  * @param  {[type]} settings [description]
  * @return {[type]}          [description]
  */
-function process (settings: MoxiedocSettings): void {
+function process (settings: MoxiedocSettings): MoxiedocResult {
   settings.out = settings.out || 'tmp/out.zip';
   settings.template = settings.template || 'cli';
 
@@ -46,7 +52,17 @@ function process (settings: MoxiedocSettings): void {
     Reporter.setLevel(Reporter.Levels.DEBUG);
   }
 
+  const result = { errors: 0, warnings: 0 };
   const builder = new Builder();
+
+  // Setup a hook to listen for errors/warnings
+  Reporter.addHook((level) => {
+    if (level === Reporter.Levels.ERROR) {
+      result.errors++;
+    } else if (level === Reporter.Levels.WARN) {
+      result.warnings++;
+    }
+  });
 
   function listFiles(dirPath: string, patterns: string[]) {
     let output: string[] = [];
@@ -87,6 +103,8 @@ function process (settings: MoxiedocSettings): void {
 
     exporter.exportTo(builder.api, settings.out);
   }
+
+  return result;
 }
 
 export {

--- a/src/lib/moxiedoc.ts
+++ b/src/lib/moxiedoc.ts
@@ -19,8 +19,8 @@ export interface MoxiedocSettings {
 }
 
 export interface MoxiedocResult {
-  errors: number;
-  warnings: number;
+  readonly errors: number;
+  readonly warnings: number;
 }
 
 /**

--- a/src/lib/moxiedoc.ts
+++ b/src/lib/moxiedoc.ts
@@ -45,11 +45,11 @@ function process (settings: MoxiedocSettings): MoxiedocResult {
   settings.template = settings.template || 'cli';
 
   if (settings.verbose) {
-    Reporter.setLevel(Reporter.Levels.INFO);
+    Reporter.setLevel(Reporter.Level.INFO);
   }
 
   if (settings.debug) {
-    Reporter.setLevel(Reporter.Levels.DEBUG);
+    Reporter.setLevel(Reporter.Level.DEBUG);
   }
 
   const result = { errors: 0, warnings: 0 };
@@ -57,9 +57,9 @@ function process (settings: MoxiedocSettings): MoxiedocResult {
 
   // Setup a hook to listen for errors/warnings
   Reporter.addHook((level) => {
-    if (level === Reporter.Levels.ERROR) {
+    if (level === Reporter.Level.ERROR) {
       result.errors++;
-    } else if (level === Reporter.Levels.WARN) {
+    } else if (level === Reporter.Level.WARN) {
       result.warnings++;
     }
   });

--- a/src/lib/reporter.ts
+++ b/src/lib/reporter.ts
@@ -1,30 +1,30 @@
 import * as clc from 'cli-color';
 
-const Levels = {
-  DEBUG: 1,
-  INFO: 2,
-  WARN: 3,
-  ERROR: 4
-};
+const enum Level {
+  DEBUG = 1,
+  INFO = 2,
+  WARN = 3,
+  ERROR= 4
+}
 
-let currentLevel = Levels.WARN;
+let currentLevel = Level.WARN;
 const hooks = [];
 
-function log (level: number, message: string): void {
+function log (level: Level, message: string): void {
   switch (level) {
-    case Levels.DEBUG:
+    case Level.DEBUG:
       message = clc.magenta('Debug: ') + message;
       break;
 
-    case Levels.INFO:
+    case Level.INFO:
       message = clc.cyan('Info: ') + message;
       break;
 
-    case Levels.WARN:
+    case Level.WARN:
       message = clc.yellow('Warning: ') + message;
       break;
 
-    case Levels.ERROR:
+    case Level.ERROR:
       message = clc.red('Error: ') + message;
       break;
   }
@@ -36,7 +36,7 @@ function log (level: number, message: string): void {
   console.log(message);
 }
 
-function createLogFunction(level: number) {
+function createLogFunction(level: Level) {
   return (...args: string[]) => {
     if (level >= currentLevel) {
       log(level, args.join(' '));
@@ -44,23 +44,23 @@ function createLogFunction(level: number) {
   };
 }
 
-function setLevel(level: number) {
+function setLevel(level: Level) {
   currentLevel = level;
 }
 
-function addHook(hook: (level: number, message: string) => void) {
+function addHook(hook: (level: Level, message: string) => void) {
   hooks.push(hook);
 }
 
-const debug = createLogFunction(Levels.DEBUG);
-const info = createLogFunction(Levels.INFO);
-const warn = createLogFunction(Levels.WARN);
-const error = createLogFunction(Levels.ERROR);
+const debug = createLogFunction(Level.DEBUG);
+const info = createLogFunction(Level.INFO);
+const warn = createLogFunction(Level.WARN);
+const error = createLogFunction(Level.ERROR);
 
 export {
   setLevel,
   addHook,
-  Levels,
+  Level,
   debug,
   info,
   warn,

--- a/src/lib/reporter.ts
+++ b/src/lib/reporter.ts
@@ -8,6 +8,7 @@ const Levels = {
 };
 
 let currentLevel = Levels.WARN;
+const hooks = [];
 
 function log (level: number, message: string): void {
   switch (level) {
@@ -28,6 +29,10 @@ function log (level: number, message: string): void {
       break;
   }
 
+  hooks.forEach((hook) => {
+    hook(level, message);
+  })
+
   console.log(message);
 }
 
@@ -43,6 +48,10 @@ function setLevel(level: number) {
   currentLevel = level;
 }
 
+function addHook(hook: (level: number, message: string) => void) {
+  hooks.push(hook);
+}
+
 const debug = createLogFunction(Levels.DEBUG);
 const info = createLogFunction(Levels.INFO);
 const warn = createLogFunction(Levels.WARN);
@@ -50,6 +59,7 @@ const error = createLogFunction(Levels.ERROR);
 
 export {
   setLevel,
+  addHook,
   Levels,
   debug,
   info,


### PR DESCRIPTION
Description of changes:
- Update moxiedoc to record the number of errors/warnings and fail with a non-zero exit code if an error occurs.
- Add a `--fail-on-warning` CLI option to also fail if warnings occur.