### PR TITLE
DOC-1601: Fixed cross references incorrectly using link macros instead of xrefs

### DIFF
--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -119,7 +119,7 @@ const buildSummary = (data: Record<string, any>): string => {
     tmp += '\n[[settings]]\n';
     tmp += '=== Settings\n';
 
-    tmp += '[options="header"]\n';
+    tmp += '[cols="2,1,4,1",options="header"]\n';
     tmp += '|===\n';
     tmp += '|Name|Type|Summary|Defined by\n';
 
@@ -137,7 +137,7 @@ const buildSummary = (data: Record<string, any>): string => {
     tmp += '\n[[properties]]\n';
     tmp += '=== Properties\n';
 
-    tmp += '[options="header"]\n';
+    tmp += '[cols="2,1,4,1",options="header"]\n';
     tmp += '|===\n';
     tmp += '|Name|Type|Summary|Defined by\n';
 
@@ -155,7 +155,7 @@ const buildSummary = (data: Record<string, any>): string => {
     tmp += '\n[[constructors-summary]]\n';
     tmp += '=== Constructors\n';
 
-    tmp += '[options="header"]\n';
+    tmp += '[cols="2,5,1",options="header"]\n';
     tmp += '|===\n';
     tmp += '|Name|Summary|Defined by\n';
 
@@ -171,7 +171,7 @@ const buildSummary = (data: Record<string, any>): string => {
   if (hasValue(data.methods)) {
     tmp += '\n[[methods-summary]]\n';
     tmp += '=== Methods\n';
-    tmp += '[options="header"]\n';
+    tmp += '[cols="2,5,1",options="header"]\n';
     tmp += '|===\n';
     tmp += '|Name|Summary|Defined by\n';
     data.methods.forEach((item) => {
@@ -186,7 +186,7 @@ const buildSummary = (data: Record<string, any>): string => {
     tmp += '\n[[events-summary]]\n';
     tmp += '=== Events\n';
 
-    tmp += '[options="header"]\n';
+    tmp += '[cols="2,5,1",options="header"]\n';
     tmp += '|===\n';
     tmp += '|Name|Summary|Defined by\n';
 

--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -39,7 +39,7 @@ const encodeStrong = (str: string): string =>
 
 // convert <code> into backtick asciidoc
 const encodeCode = (str: string) => {
-  const regex = /<code>(.*?)<\/code>/g;
+  const regex = /<code>(.*?)<\/code>/;
   let matches;
   while ((matches = regex.exec(str))) {
     str = str.replace(matches[0], '`' + matches[1] + '`').replace('"`', '`').replace('`"', '`');

--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -8,7 +8,7 @@ export interface PageOutput {
 }
 
 // TODO: we can pass this through later
-const baseURL = '';
+const basePath = 'apis/';
 
 const hasValue = <T>(x: T): x is NonNullable<T> => {
   // empty helper for strings, objects, arrays
@@ -71,11 +71,11 @@ const cleanup = (str: string): string => {
 const getNameFromFullName = (name: string): string =>
   name.split('.').slice(-1).join('');
 
-const generateTypeLink = (type: string): string =>
-  type.includes('tinymce', 0) ? 'link:' + baseURL + type.toLowerCase() + '.html[' + getNameFromFullName(type) + ']' : type;
+const generateTypeXref = (type: string): string =>
+  type.includes('tinymce', 0) ? 'xref:' + basePath + type.toLowerCase() + '.adoc[' + getNameFromFullName(type) + ']' : type;
 
-const generateDefinedByLink = (definedBy: string) =>
-  'link:' + baseURL + definedBy.toLowerCase() + '.html[' + getNameFromFullName(definedBy) + ']';
+const generateDefinedByXref = (definedBy: string) =>
+  'xref:' + basePath + definedBy.toLowerCase() + '.adoc[' + getNameFromFullName(definedBy) + ']';
 
 const generateExamples = (examples: Array<{ content: string }>): string => {
   let tmp = '\n==== Examples\n';
@@ -91,7 +91,7 @@ const generateExamples = (examples: Array<{ content: string }>): string => {
 const generateParameters = (params: Param[]): string => {
   let tmp = '\n==== Parameters\n';
   params.forEach((param) => {
-    tmp += '\n* `' + param.name + ' (' + param.types.map(generateTypeLink).join(' | ') + ')` - ' + cleanup(param.desc);
+    tmp += '\n* `' + param.name + ' (' + param.types.map(generateTypeXref).join(' | ') + ')` - ' + cleanup(param.desc);
   });
   return tmp + '\n';
 };
@@ -99,7 +99,7 @@ const generateParameters = (params: Param[]): string => {
 const generateReturn = (ret: Return): string => {
   let tmp = '\n==== Return value\n';
   ret.types.forEach((type) => {
-    tmp += '\n* `' + generateTypeLink(type) + '` - ' + cleanup(ret.desc);
+    tmp += '\n* `' + generateTypeXref(type) + '` - ' + cleanup(ret.desc);
   });
   tmp += '\n';
   return tmp;
@@ -120,9 +120,9 @@ const buildSummary = (data: Record<string, any>): string => {
 
     data.settings.forEach((item) => {
       tmp += '|' + item.name;
-      tmp += '|`' + generateTypeLink(item.dataTypes[0]) + '`';
+      tmp += '|`' + generateTypeXref(item.dataTypes[0]) + '`';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + generateDefinedByLink(item.definedBy) + '`\n';
+      tmp += '|`' + generateDefinedByXref(item.definedBy) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -138,9 +138,9 @@ const buildSummary = (data: Record<string, any>): string => {
 
     data.properties.forEach((item) => {
       tmp += '|' + item.name;
-      tmp += '|`' + generateTypeLink(item.dataTypes[0]) + '`';
+      tmp += '|`' + generateTypeXref(item.dataTypes[0]) + '`';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + generateDefinedByLink(item.definedBy) + '`\n';
+      tmp += '|`' + generateDefinedByXref(item.definedBy) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -155,9 +155,9 @@ const buildSummary = (data: Record<string, any>): string => {
     tmp += '|Name|Summary|Defined by\n';
 
     data.constructors.forEach((item) => {
-      tmp += '|link:#' + item.name + '[' + item.name + '()]';
+      tmp += '|xref:#' + item.name + '[' + item.name + '()]';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + generateDefinedByLink(item.definedBy) + '`\n';
+      tmp += '|`' + generateDefinedByXref(item.definedBy) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -170,7 +170,7 @@ const buildSummary = (data: Record<string, any>): string => {
     tmp += '|===\n';
     tmp += '|Name|Summary|Defined by\n';
     data.methods.forEach((item) => {
-      tmp += '|link:#' + item.name + '[' + item.name + '()]|' + cleanup(item.desc) + '|`' + generateDefinedByLink(item.definedBy) + '`\n';
+      tmp += '|xref:#' + item.name + '[' + item.name + '()]|' + cleanup(item.desc) + '|`' + generateDefinedByXref(item.definedBy) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -186,9 +186,9 @@ const buildSummary = (data: Record<string, any>): string => {
     tmp += '|Name|Summary|Defined by\n';
 
     data.events.forEach((item) => {
-      tmp += '|link:#' + item.name + '[' + item.name + ']';
+      tmp += '|xref:#' + item.name + '[' + item.name + ']';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + generateDefinedByLink(item.definedBy) + '`\n';
+      tmp += '|`' + generateDefinedByXref(item.definedBy) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -313,7 +313,7 @@ const convert = (pages: PageOutput[][]): PageOutput[][] => pages.map((page) => {
     tmp += '\n[[extends]]\n';
     tmp += '== Extends\n';
     data.borrows.forEach((item) => {
-      tmp += '\n * link:' + baseURL + item.toLowerCase() + '.html[' + item + ']\n';
+      tmp += '\n * xref:' + basePath + item.toLowerCase() + '.adoc[' + item + ']\n';
     });
   }
 

--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -71,11 +71,16 @@ const cleanup = (str: string): string => {
 const getNameFromFullName = (name: string): string =>
   name.split('.').slice(-1).join('');
 
-const generateTypeXref = (type: string): string =>
-  type.includes('tinymce', 0) ? 'xref:' + basePath + type.toLowerCase() + '.adoc[' + getNameFromFullName(type) + ']' : type;
+const getFilePathFromFullName = (name: string): string => {
+  const filename = name.toLowerCase() === 'tinymce' ? 'tinymce.root' : name.toLowerCase();
+  return basePath + filename + '.adoc';
+};
 
-const generateDefinedByXref = (definedBy: string) =>
-  'xref:' + basePath + definedBy.toLowerCase() + '.adoc[' + getNameFromFullName(definedBy) + ']';
+const generateTypeXref = (type: string): string =>
+  type.includes('tinymce', 0) ? 'xref:' + getFilePathFromFullName(type) + '[' + getNameFromFullName(type) + ']' : type;
+
+const generateDefinedByXref = (definedBy: string): string =>
+  'xref:' + getFilePathFromFullName(definedBy) + '[' + getNameFromFullName(definedBy) + ']';
 
 const generateExamples = (examples: Array<{ content: string }>): string => {
   let tmp = '\n==== Examples\n';


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Swap to using `xref:` macros for cross page links instead of using `link:` macros which don't work when changing various Antora configuration.
* Fixed the link for the root page being generated incorrectly which lead to broken links
* Fixed a couple other minor issues I found when reviewing the API docs (table column widths and `<code>` HTML elements not being converted if more than 1 existed)

Pre-checks:
* [x] ~Changelog entry added~ 0.2.0 hasn't been released yet so no changelog atm
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Review comments resolved
