### PR TITLE
DOC-1615: Fixed certain AsciiDoc special chars not being escaped

### DIFF
--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -29,13 +29,13 @@ const escapeComments = (str: string): string =>
 const encodeBR = (str: string): string =>
   str.replace(/<br\s*\/?>/g, '\n');
 
-// convert <em> into _italics_ asciidoc
+// convert <em> into __italics__ asciidoc
 const encodeEM = (str: string): string =>
-  str.replace(/<\/?em>/g, '_');
+  str.replace(/<\/?em>/g, '__');
 
-// convert <strong> into *bold* asciidoc
+// convert <strong> into **bold** asciidoc
 const encodeStrong = (str: string): string =>
-  str.replace(/<\/?strong>/g, '*');
+  str.replace(/<\/?strong>/g, '**');
 
 // convert <code> into backtick asciidoc
 const encodeCode = (str: string) => {
@@ -58,13 +58,24 @@ const encodeLinks = (str: string): string => {
   }
 };
 
+// escape special asciidoc characters
+const specialChars = {
+  '|': '{vbar}',
+  '+': '{plus}',
+  '*': '{asterisk}'
+};
+const escapeSpecialChars = (str: string): string =>
+  str.replace(/[|+*]/g, (match) => specialChars[match] || match);
+
 // convert content that looks like asciidoc attributes (e.g {0}) to literal strings
+// Note: Special characters should not be escaped
+const specialAttrs = Object.values(specialChars);
 const escapeAttributes = (str: string): string =>
-  str.replace(/(\{\s*[\w\d-]+\s*\})/g, '+$1+');
+  str.replace(/(\{\s*[\w\d-]+\s*\})/g, (match) => specialAttrs.indexOf(match) !== -1 ? match : `+${match}+`);
 
 // runs a bunch of required cleanup filters, where embedded code/text can break asciidoc rendering
 const cleanup = (str: string): string => {
-  const filters = [ escapeComments, encodeBR, encodeEM, encodeStrong, encodeLinks, encodeCode, escapeAttributes ];
+  const filters = [ escapeSpecialChars, escapeAttributes, escapeComments, encodeBR, encodeEM, encodeStrong, encodeLinks, encodeCode ];
   return filters.reduce((acc, filter) => filter(acc), str);
 };
 


### PR DESCRIPTION
Related Ticket: DOC-1615

Description of Changes:
* Fixed pipe characters breaking the TinyMCE schema API docs by escaping them using AsciiDoc attributes (also added some other common ones)
* Changed the bold/italic markup to use 2 chars instead of one so that it works inside words and to prevent conflicts with content.

Pre-checks:
* [x] ~Changelog entry added~ Antora converter hasn't been released yet so no additional changelog needed
* [x] package.json version bumped (if first change of new major/minor)
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Review comments resolved
