### PR TITLE
DOC-1610: Fixed the asciidoc document metadata being generated incorrectly

### DIFF
--- a/src/templates/antora/member.handlebars
+++ b/src/templates/antora/member.handlebars
@@ -1,5 +1,5 @@
 = {{fullName}}
-:description: "{{desc}}"
-:keywords: "{{keywords}}"
-:title_nav: "{{fullName}}"
-:moxie-type: "api"
+:navtitle: {{fullName}}
+:description: {{desc}}
+:keywords: {{keywords}}
+:moxie-type: api

--- a/src/templates/antora/template.ts
+++ b/src/templates/antora/template.ts
@@ -158,7 +158,7 @@ const getMemberPages = (root: Api, templateDelegate: HandlebarsTemplateDelegate,
   data.events = sortMembers(data.events);
   data.keywords = sortMembers(data.keywords);
 
-  data.keywords = data.keywords.join(' ');
+  data.keywords = data.keywords.join(', ');
   return [{
     type: 'json',
     filename: createFileName(data, 'json'),


### PR DESCRIPTION
Related Ticket: DOC-1610

Description of Changes:
* Fixed the asciidoc document metadata incorrectly being quoted
* Fixed the wrong name being used for the nav title attribute
* Fixed the keywords incorrectly being generated as a space separated string when they should be comma separated: https://docs.asciidoctor.org/asciidoc/latest/document/metadata/#keywords

Pre-checks:
* [x] ~Changelog entry added~ Antora converter hasn't been released yet
* [x] package.json version bumped (if first change of new major/minor)
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Review comments resolved
