### PR TITLE
DOC-1613: Fixed incorrectly using the summary instead of the description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.2.1 - 2022-04-29
+
+### Fixed
+- The `antora` template used the incorrect data for page introductions.
+
 ## 0.2.0 - 2022-04-05
 
 ### Added

--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -27,7 +27,7 @@ const escapeComments = (str: string): string =>
 
 // convert BRs found into asciidoc \n
 const encodeBR = (str: string): string =>
-  str.replace(/<br\s*\/?>/g, '\n');
+  str.replace(/\s*<br\s*\/?>\s*/g, '\n');
 
 // convert <em> into __italics__ asciidoc
 const encodeEM = (str: string): string =>
@@ -318,8 +318,13 @@ const convert = (pages: PageOutput[][]): PageOutput[][] => pages.map((page) => {
   // data.borrows = data.borrows || []
   // data.examples = data.examples || []
 
-  // summary
-  if (hasValue(data.summary)) {
+  // description
+  if (hasValue(data.desc)) {
+    tmp += '\n' + cleanup(data.desc) + '\n';
+  }
+
+  // summary if not part of the description
+  if (hasValue(data.summary) && (!hasValue(data.desc) || !data.desc.includes(data.summary))) {
     tmp += '\n' + cleanup(data.summary) + '\n';
   }
 

--- a/src/templates/antora/template.ts
+++ b/src/templates/antora/template.ts
@@ -100,6 +100,7 @@ const getMemberPages = (root: Api, templateDelegate: HandlebarsTemplateDelegate,
   const data = type.toJSON();
   data.datapath = data.type + '_' + data.fullName.replace(/\./g, '_').toLowerCase();
   data.desc = data.desc.replace(/\n/g, ' ');
+  data.summary = data.summary.replace(/\n/g, ' ');
 
   data.constructors = [];
   data.methods = [];


### PR DESCRIPTION
Related Ticket: DOC-1613

Description of Changes:

Fixes an issue where the `summary` was used when the `description` should be used in most cases. It also keeps the summary when it's different to the description, as the old docs used to.

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Review comments resolved
