### PR TITLE
TINY-8747: Added file structure option to support legacy output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.3.0 - 2022-08-23
 
 ### Added
-- New `structure` option for specifying `legacy` nested structure for antora docs, or `default` file structure.
+- New `structure` option for specifying `legacy` nested structure for antora docs.
 
 ## 0.2.1 - 2022-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.3.0 - 2022-07-12
+## 0.3.0 - 2022-08-23
 
 ### Added
 - New `structure` option for specifying `legacy` nested structure for antora docs, or `default` file structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.2.2 - 2022-07-12
+## 0.3.0 - 2022-07-12
 
 ### Added
 - New `structure` option with default `flat` file structure or `legacy` nested folders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.3.0 - 2022-07-12
 
 ### Added
-- New `structure` option with default `flat` file structure or `legacy` nested folders.
+- New `structure` option for specifying `legacy` nested structure for antora docs, or `default` file structure.
 
 ## 0.2.1 - 2022-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.2.2 - 2022-07-12
+
+### Added
+- New `structure` option with default `flat` file structure or `legacy` nested folders.
+
 ## 0.2.1 - 2022-04-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # moxiedoc
 
-### Introduction
+## Introduction
 
 This project maintains Moxiedoc, a tool used to build API reference documentation. If you have any modifications you wish to contribute, fork this project, make the changes and submit a pull request. You will need to sign the contributors license agreement, which will be emailed to you upon creating the pull request.
 
-### Using Moxiedoc
+## Using Moxiedoc
 
 To create API reference documentation from a development version of moxiedoc, run:
 
@@ -13,7 +13,7 @@ yarn build
 node ./dist/lib/cli.js PATH/TO/API_FILE_FOLDER
 ```
 
-### Moxiedoc Options
+## Moxiedoc Options
 
 Moxiedoc provides the following options to customise the format of the output documentation:
 
@@ -27,7 +27,7 @@ Moxiedoc provides the following options to customise the format of the output do
 --fail-on-warning: fail if warnings are produced
 ```
 
-### Schema
+## Schema
 
 The output JSON takes the form of the following schema:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Moxiedoc provides the following options to customise the format of the output do
 ```
 -o --out <path>: location of output files, default: 'tmp/out.zip'
 -t --template <template>: documentation type: default: 'cli'; 'antora', 'github', 'moxiewiki', 'singlehtml', 'tinymcenext', 'xml'
--s --structure <type>: default: 'flat', 'legacy'
+-s --structure <type>: default: 'default'; 'legacy'
 -v --verbose: verbose output
 --debug: debug output
 --dry: dry run only syntax check

--- a/README.md
+++ b/README.md
@@ -1,5 +1,36 @@
 # moxiedoc
 
+### Introduction
+
+This project maintains Moxiedoc, a tool used to build API reference documentation. If you have any modifications you wish to contribute, fork this project, make the changes and submit a pull request. You will need to sign the contributors license agreement, which will be emailed to you upon creating the pull request.
+
+### Using Moxiedoc
+
+To create API reference documentation from a development version of moxiedoc, run:
+
+```
+yarn build
+node ./dist/lib/cli.js PATH/TO/API_FILE_FOLDER
+```
+
+### Moxiedoc Options
+
+Moxiedoc provides the following options to customise the format of the output documentation:
+
+```
+-o --out <path>: location of output files, default: 'tmp/out.zip'
+-t --template <template>: documentation type: default: 'cli'; 'antora', 'github', 'moxiewiki', 'singlehtml', 'tinymcenext', 'xml'
+-s --structure <type>: default: 'flat', 'legacy'
+-v --verbose: verbose output
+--debug: debug output
+--dry: dry run only syntax check
+--fail-on-warning: fail if warnings are produced
+```
+
+### Schema
+
+The output JSON takes the form of the following schema:
+
 ```json
 {
   "namespace.Class": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/moxiedoc",
-  "version": "0.2.2-rc",
+  "version": "0.3.0-rc",
   "description": "A tool for generating API documentation",
   "author": "Tiny Technologies, Inc",
   "bugs": {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,20 +7,10 @@ class Api {
   private _rootTypes: Type[] = [];
   private _rootNamespaces: Namespace[] = [];
 
-  private _structure: string = 'flat';
-
   public static getNamespaceFromFullName(fullName: string): string {
     const chunks = fullName.split('.');
     chunks.pop();
     return chunks.join('.');
-  }
-
-  public setStructure(legacy: string): void {
-    this._structure = legacy;
-  }
-
-  public getStructure(): string {
-    return this._structure;
   }
 
   public getRootTypes(): Type[] {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,10 +7,20 @@ class Api {
   private _rootTypes: Type[] = [];
   private _rootNamespaces: Namespace[] = [];
 
+  private _structure: string = 'flat';
+
   public static getNamespaceFromFullName(fullName: string): string {
     const chunks = fullName.split('.');
     chunks.pop();
     return chunks.join('.');
+  }
+
+  public setStructure(legacy: string): void {
+    this._structure = legacy;
+  }
+
+  public getStructure(): string {
+    return this._structure;
   }
 
   public getRootTypes(): Type[] {

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -16,6 +16,7 @@ program
   .option('--debug', 'debug output')
   .option('--dry', 'dry run only syntax check')
   .option('--fail-on-warning', 'fail if warnings are produced')
+  .option('-l, <name>/--legacy', 'output file structure, default: flat')
   .parse(process.argv);
 
 program.on('--help', () => {

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -8,11 +8,11 @@ import { MoxiedocSettings, process as moxieDocProcess } from './moxiedoc';
 process.argv[1] = 'moxiedoc';
 
 program
-  .version('0.2.2')
+  .version('0.3.0')
   .usage('[options] <dir ...>')
   .option('-o, --out <path>', 'output path, default: out')
   .option('-t, --template <template>', 'template name, default: cli')
-  .option('-s, --structure <type>', 'output file structure, default: flat')
+  .option('-s, --structure <type>', 'output file structure')
   .option('-v, --verbose', 'verbose output')
   .option('--debug', 'debug output')
   .option('--dry', 'dry run only syntax check')

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -12,7 +12,7 @@ program
   .usage('[options] <dir ...>')
   .option('-o, --out <path>', 'output path, default: out')
   .option('-t, --template <template>', 'template name, default: cli')
-  .option('-s, --structure <type>', 'output file structure')
+  .option('-s, --structure <type>', 'output file structure, default: default')
   .option('-v, --verbose', 'verbose output')
   .option('--debug', 'debug output')
   .option('--dry', 'dry run only syntax check')

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -8,10 +8,10 @@ import { MoxiedocSettings, process as moxieDocProcess } from './moxiedoc';
 process.argv[1] = 'moxiedoc';
 
 program
-  .version('0.2.0')
+  .version('0.2.2')
   .usage('[options] <dir ...>')
   .option('-o, --out <path>', 'output path, default: out')
-  .option('-t, --template <template>', 'template name')
+  .option('-t, --template <template>', 'template name, default: cli')
   .option('-s, --structure <type>', 'output file structure, default: flat')
   .option('-v, --verbose', 'verbose output')
   .option('--debug', 'debug output')

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -12,11 +12,11 @@ program
   .usage('[options] <dir ...>')
   .option('-o, --out <path>', 'output path, default: out')
   .option('-t, --template <template>', 'template name')
+  .option('-s, --structure <type>', 'output file structure, default: flat')
   .option('-v, --verbose', 'verbose output')
   .option('--debug', 'debug output')
   .option('--dry', 'dry run only syntax check')
   .option('--fail-on-warning', 'fail if warnings are produced')
-  .option('-l, <name>/--legacy', 'output file structure, default: flat')
   .parse(process.argv);
 
 program.on('--help', () => {

--- a/src/lib/exporter.ts
+++ b/src/lib/exporter.ts
@@ -1,7 +1,10 @@
 import { Api } from './api';
 
+export type ExportStructure = 'default' | 'legacy';
+
 export interface ExporterSettings {
   readonly template: string;
+  readonly structure: ExportStructure;
 }
 
 /**
@@ -25,7 +28,7 @@ class Exporter {
     const templatePath = '../templates/' + this.settings.template + '/template.js';
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    require(templatePath).template.call(this, types, dirPath);
+    require(templatePath).template.call(this, types, dirPath, this.settings.structure);
   }
 }
 

--- a/src/lib/moxiedoc.ts
+++ b/src/lib/moxiedoc.ts
@@ -17,6 +17,7 @@ export interface MoxiedocSettings {
   paths: string[];
   dry?: boolean;
   failOnWarning?: boolean;
+  legacy?: string;
 }
 
 export interface MoxiedocResult {
@@ -44,6 +45,7 @@ export interface MoxiedocResult {
 const process = (settings: MoxiedocSettings): MoxiedocResult => {
   settings.out = settings.out || 'tmp/out.zip';
   settings.template = settings.template || 'cli';
+  settings.legacy = settings.legacy || 'flat';
 
   if (settings.verbose) {
     Reporter.setLevel(Reporter.Level.INFO);
@@ -94,6 +96,8 @@ const process = (settings: MoxiedocSettings): MoxiedocResult => {
       builder.parser.parseFile(filePath);
     }
   });
+
+  builder.api.setStructure(settings.legacy);
 
   builder.api.removePrivates();
 

--- a/src/lib/moxiedoc.ts
+++ b/src/lib/moxiedoc.ts
@@ -3,7 +3,7 @@ import * as matcher from 'matcher';
 import * as path from 'path';
 
 import { Builder } from './builder';
-import { Exporter } from './exporter';
+import { Exporter, ExportStructure } from './exporter';
 import * as Reporter from './reporter';
 
 exports.Builder = Builder;
@@ -12,7 +12,7 @@ exports.Exporter = Exporter;
 export interface MoxiedocSettings {
   out?: string;
   template?: string;
-  structure?: string;
+  structure?: ExportStructure;
   verbose?: boolean;
   debug?: boolean;
   paths: string[];
@@ -45,7 +45,7 @@ export interface MoxiedocResult {
 const process = (settings: MoxiedocSettings): MoxiedocResult => {
   settings.out = settings.out || 'tmp/out.zip';
   settings.template = settings.template || 'cli';
-  settings.structure = settings.structure || 'flat';
+  settings.structure = settings.structure || 'default';
 
   if (settings.verbose) {
     Reporter.setLevel(Reporter.Level.INFO);
@@ -97,13 +97,12 @@ const process = (settings: MoxiedocSettings): MoxiedocResult => {
     }
   });
 
-  builder.api.setStructure(settings.structure);
-
   builder.api.removePrivates();
 
   if (!settings.dry) {
     const exporter = new Exporter({
-      template: settings.template
+      template: settings.template,
+      structure: settings.structure
     });
 
     exporter.exportTo(builder.api, settings.out);

--- a/src/lib/moxiedoc.ts
+++ b/src/lib/moxiedoc.ts
@@ -12,12 +12,12 @@ exports.Exporter = Exporter;
 export interface MoxiedocSettings {
   out?: string;
   template?: string;
+  structure?: string;
   verbose?: boolean;
   debug?: boolean;
   paths: string[];
   dry?: boolean;
   failOnWarning?: boolean;
-  legacy?: string;
 }
 
 export interface MoxiedocResult {
@@ -45,7 +45,7 @@ export interface MoxiedocResult {
 const process = (settings: MoxiedocSettings): MoxiedocResult => {
   settings.out = settings.out || 'tmp/out.zip';
   settings.template = settings.template || 'cli';
-  settings.legacy = settings.legacy || 'flat';
+  settings.structure = settings.structure || 'flat';
 
   if (settings.verbose) {
     Reporter.setLevel(Reporter.Level.INFO);
@@ -97,7 +97,7 @@ const process = (settings: MoxiedocSettings): MoxiedocResult => {
     }
   });
 
-  builder.api.setStructure(settings.legacy);
+  builder.api.setStructure(settings.structure);
 
   builder.api.removePrivates();
 

--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -1,6 +1,10 @@
+
+import { ExportStructure } from 'src/lib/exporter';
+
 import { Return } from '../../lib/member';
 import { Param } from '../../lib/param';
-import { Util, PageOutput } from './util';
+import { PageOutput } from './util';
+import * as Util from './util';
 
 const hasValue = <T>(x: T): x is NonNullable<T> => {
   // empty helper for strings, objects, arrays
@@ -82,23 +86,23 @@ const generateExamples = (examples: Array<{ content: string }>): string => {
   return tmp;
 };
 
-const generateParameters = (params: Param[], util: Util): string => {
+const generateParameters = (params: Param[], structure: ExportStructure): string => {
   let tmp = '\n==== Parameters\n';
   params.forEach((param) => {
-    tmp += '\n* `' + param.name + ' (' + param.types.map((type) => util.generateTypeXref(type)).join(' | ') + ')` - ' + cleanup(param.desc);
+    tmp += '\n* `' + param.name + ' (' + param.types.map((type) => Util.generateTypeXref(type, structure)).join(' | ') + ')` - ' + cleanup(param.desc);
   });
   return tmp + '\n';
 };
 
-const generateReturn = (ret: Return, util: Util): string => {
+const generateReturn = (ret: Return, structure: ExportStructure): string => {
   let tmp = '\n==== Return value\n';
   ret.types.forEach((type) => {
-    tmp += '\n* `' + util.generateTypeXref(type) + '` - ' + cleanup(ret.desc);
+    tmp += '\n* `' + Util.generateTypeXref(type, structure) + '` - ' + cleanup(ret.desc);
   });
   return tmp += '\n';
 };
 
-const buildSummary = (data: Record<string, any>, util: Util): string => {
+const buildSummary = (data: Record<string, any>, structure: ExportStructure): string => {
   let tmp = '';
 
   // settings
@@ -113,9 +117,9 @@ const buildSummary = (data: Record<string, any>, util: Util): string => {
 
     data.settings.forEach((item) => {
       tmp += '|' + item.name;
-      tmp += '|`' + util.generateTypeXref(item.dataTypes[0]) + '`';
+      tmp += '|`' + Util.generateTypeXref(item.dataTypes[0], structure) + '`';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + util.generateXref(item.definedBy) + '`\n';
+      tmp += '|`' + Util.generateXref(item.definedBy, structure) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -131,9 +135,9 @@ const buildSummary = (data: Record<string, any>, util: Util): string => {
 
     data.properties.forEach((item) => {
       tmp += '|' + item.name;
-      tmp += '|`' + util.generateTypeXref(item.dataTypes[0]) + '`';
+      tmp += '|`' + Util.generateTypeXref(item.dataTypes[0], structure) + '`';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + util.generateXref(item.definedBy) + '`\n';
+      tmp += '|`' + Util.generateXref(item.definedBy, structure) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -150,7 +154,7 @@ const buildSummary = (data: Record<string, any>, util: Util): string => {
     data.constructors.forEach((item) => {
       tmp += '|xref:#' + item.name + '[' + item.name + '()]';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + util.generateXref(item.definedBy) + '`\n';
+      tmp += '|`' + Util.generateXref(item.definedBy, structure) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -163,7 +167,7 @@ const buildSummary = (data: Record<string, any>, util: Util): string => {
     tmp += '|===\n';
     tmp += '|Name|Summary|Defined by\n';
     data.methods.forEach((item) => {
-      tmp += '|xref:#' + item.name + '[' + item.name + '()]|' + cleanup(item.desc) + '|`' + util.generateXref(item.definedBy) + '`\n';
+      tmp += '|xref:#' + item.name + '[' + item.name + '()]|' + cleanup(item.desc) + '|`' + Util.generateXref(item.definedBy, structure) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -181,7 +185,7 @@ const buildSummary = (data: Record<string, any>, util: Util): string => {
     data.events.forEach((item) => {
       tmp += '|xref:#' + item.name + '[' + item.name + ']';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + util.generateXref(item.definedBy) + '`\n';
+      tmp += '|`' + Util.generateXref(item.definedBy, structure) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -189,7 +193,7 @@ const buildSummary = (data: Record<string, any>, util: Util): string => {
   return tmp.length > 0 ? '\n[[summary]]\n== Summary\n' + tmp : tmp;
 };
 
-const buildConstructor = (data: Record<string, any>, util: Util): string => {
+const buildConstructor = (data: Record<string, any>, structure: ExportStructure): string => {
   let tmp = '';
 
   if (hasValue(data.constructors)) {
@@ -210,11 +214,11 @@ const buildConstructor = (data: Record<string, any>, util: Util): string => {
       }
 
       if (hasValue(constructor.params)) {
-        tmp += generateParameters(constructor.params, util);
+        tmp += generateParameters(constructor.params, structure);
       }
 
       if (hasValue(constructor.return) && hasValue(constructor.return.types)) {
-        tmp += generateReturn(constructor.return, util);
+        tmp += generateReturn(constructor.return, structure);
       }
     });
   }
@@ -222,7 +226,7 @@ const buildConstructor = (data: Record<string, any>, util: Util): string => {
   return tmp;
 };
 
-const buildMethods = (data: Record<string, any>, util: Util): string => {
+const buildMethods = (data: Record<string, any>, structure: ExportStructure): string => {
   let tmp = '';
 
   if (hasValue(data.methods)) {
@@ -242,11 +246,11 @@ const buildMethods = (data: Record<string, any>, util: Util): string => {
       }
 
       if (hasValue(method.params)) {
-        tmp += generateParameters(method.params, util);
+        tmp += generateParameters(method.params, structure);
       }
 
       if (hasValue(method.return) && hasValue(method.return.types)) {
-        tmp += generateReturn(method.return, util);
+        tmp += generateReturn(method.return, structure);
       }
 
       tmp += `\n'''\n`;
@@ -256,7 +260,7 @@ const buildMethods = (data: Record<string, any>, util: Util): string => {
   return tmp;
 };
 
-const buildEvents = (data: Record<string, any>, util: Util): string => {
+const buildEvents = (data: Record<string, any>, structure: ExportStructure): string => {
   let tmp = '';
 
   // untested snippet, no events data
@@ -269,7 +273,7 @@ const buildEvents = (data: Record<string, any>, util: Util): string => {
       tmp += cleanup(event.desc) + '\n';
 
       if (hasValue(event.params)) {
-        tmp += generateParameters(event.params, util);
+        tmp += generateParameters(event.params, structure);
       }
     });
   }
@@ -277,7 +281,7 @@ const buildEvents = (data: Record<string, any>, util: Util): string => {
   return tmp;
 };
 
-const convert = (pages: PageOutput[][], util: Util): PageOutput[][] => pages.map((page) => {
+const convert = (pages: PageOutput[][], structure: ExportStructure): PageOutput[][] => pages.map((page) => {
   // page[0] is json
   // page[1] is adoc
   const data = JSON.parse(page[0].content);
@@ -311,7 +315,7 @@ const convert = (pages: PageOutput[][], util: Util): PageOutput[][] => pages.map
     tmp += '\n[[extends]]\n';
     tmp += '== Extends\n';
     data.borrows.forEach((item) => {
-      tmp += '\n * ' + util.generateXref(item) + '\n';
+      tmp += '\n * ' + Util.generateXref(item, structure) + '\n';
     });
   }
 
@@ -327,10 +331,10 @@ const convert = (pages: PageOutput[][], util: Util): PageOutput[][] => pages.map
     });
   }
 
-  tmp += buildSummary(data, util);
-  tmp += buildConstructor(data, util);
-  tmp += buildMethods(data, util);
-  tmp += buildEvents(data, util);
+  tmp += buildSummary(data, structure);
+  tmp += buildConstructor(data, structure);
+  tmp += buildMethods(data, structure);
+  tmp += buildEvents(data, structure);
 
   // return the applied antora page mutation
   page[1] = {

--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -76,35 +76,24 @@ const cleanup = (str: string): string => {
   return filters.reduce((acc, filter) => filter(acc), str);
 };
 
-const getNameFromFullName = (name: string): string =>
-  name.split('.').slice(-1).join('');
-
 const getFilePathFromFullName = (name: string): string => {
   const filename = name.toLowerCase() === 'tinymce' ? 'tinymce.root' : name.toLowerCase();
   return 'apis/' + filename + '.adoc';
 };
 
 const getFilePathFromFullNameLegacy = (name: string): string => {
-  const folder = getNameFromFullName(name) + '/';
-  const filename = name.toLowerCase() === 'tinymce' ? 'root_tinymce' : name.toLowerCase();
+  const folder = name.split('.').slice(0, -1).join('.') + '/';
+  const filename = name.toLowerCase() === 'tinymce' ? 'tinymce/root_tinymce' : name.toLowerCase();
   return 'api/' + folder + filename + '.adoc';
 };
 
-const getFilePath = (structure: string): Function => {
-  switch (structure) {
-    case 'flat':
-      return getFilePathFromFullName;
+const getFilePath = (structure: string): Function =>
+  structure === 'legacy' ? getFilePathFromFullNameLegacy : getFilePathFromFullName;
 
-    case 'legacy':
-      return getFilePathFromFullNameLegacy;
-
-    default:
-      return getFilePathFromFullName;
-  }
+const generateXref = (name: string, structure: string, title?: string): string => {
+  title = title || name.split('.').slice(-1).join('');
+  return 'xref:' + getFilePath(structure)(name) + '[' + title + ']';
 };
-
-const generateXref = (name: string, structure: string): string =>
-  'xref:' + getFilePath(structure)(name) + '[' + getNameFromFullName(name) + ']';
 
 const generateTypeXref = (type: string, structure: string): string =>
   type.includes('tinymce', 0) ? generateXref(type, structure) : type;
@@ -380,6 +369,5 @@ const convert = (pages: PageOutput[][], structure: string): PageOutput[][] => pa
 
 export {
   getFilePath,
-  generateXref,
   convert
 };

--- a/src/templates/antora/template.ts
+++ b/src/templates/antora/template.ts
@@ -183,13 +183,11 @@ const template = (root: Api, toPath: string, structure: ExportStructure): void =
   const navPages = Util.generateNavPages(indexPage, structure);
 
   if (structure === 'legacy') {
-    Util.generateIndexPages(indexPage, sortedTypes, memberTemplate, structure)
+    Util.generateLegacyIndexPages(indexPage, sortedTypes, memberTemplate, structure)
       .forEach((pageOutput) => navPages.push(pageOutput));
   }
 
-  navPages.forEach((page) => {
-    addPage(page);
-  });
+  navPages.forEach(addPage);
 
   // create all json and adoc for each item
   const pages: PageOutput[][] = sortedTypes.map(getMemberPages.bind(null, root, memberTemplate, structure));

--- a/src/templates/antora/template.ts
+++ b/src/templates/antora/template.ts
@@ -40,14 +40,19 @@ const navToAdoc = (indexPage: NavFile, structure: string): string => {
   return adoc;
 };
 
-const namespaceNavToAdoc = (namespace: NavFile): string => {
-  let adoc = navLine(namespace.title, 1);
+const indexToAdoc = (namespace: NavFile): string => {
+  let adoc = '= ' + namespace.title + '\n\n';
+  adoc += '[cols="1,1"]\n';
+  adoc += '|===\n\n';
   if (namespace.pages) {
     namespace.pages.forEach((pageFile) => {
-      const namespaceLine = generateXref('api/' + namespace.path, pageFile.path + '.adoc', pageFile.title);
-      adoc += navLine(namespaceLine, 2);
+      adoc += 'a|\n';
+      adoc += '[.lead]\n';
+      adoc += generateXref('api/' + namespace.path, pageFile.path + '.adoc', pageFile.title) + '\n\n';
     });
   }
+  adoc += 'a|\n\n';
+  adoc += '|===';
   return adoc;
 };
 
@@ -295,8 +300,8 @@ const template = (root: Api, toPath: string): void => {
   if (structure === 'legacy') {
     indexPage.pages.forEach((namespace) => {
       addPage({
-        filename: 'api/' + namespace.path + '/' + namespace.path + '_nav.adoc',
-        content: namespaceNavToAdoc(namespace)
+        filename: 'api/' + namespace.path + '/index_' + namespace.path + '.adoc',
+        content: indexToAdoc(namespace)
       });
     });
   }

--- a/src/templates/antora/util.ts
+++ b/src/templates/antora/util.ts
@@ -203,8 +203,12 @@ const generateNavPages = (indexPage: NavFile, structure: ExportStructure): PageO
   return navPages;
 };
 
-const legacyIndexToAdoc =
-(namespace: NavFile, template: HandlebarsTemplateDelegate, descriptions: Record<string, string>, structure: ExportStructure): string => {
+const legacyIndexToAdoc = (
+  namespace: NavFile,
+  template: HandlebarsTemplateDelegate,
+  descriptions: Record<string, string>,
+  structure: ExportStructure
+): string => {
   const keywords = [ getApiFromFullName(namespace.title) ];
   const indexPageLines = [
     '\n== ' + namespaceDescriptions[namespace.title.toLowerCase()] + '\n\n'
@@ -236,8 +240,12 @@ const legacyIndexToAdoc =
   return adoc;
 };
 
-const generateLegacyIndexPages =
-(indexPage: NavFile, sortedTypes: Type[], memberTemplate: HandlebarsTemplateDelegate, structure: ExportStructure): PageOutput[] => {
+const generateLegacyIndexPages = (
+  indexPage: NavFile,
+  sortedTypes: Type[],
+  memberTemplate: HandlebarsTemplateDelegate,
+  structure: ExportStructure
+): PageOutput[] => {
   const newNavPages = [] as PageOutput[];
   const descriptions = getDescriptionsFromTypes(sortedTypes);
   indexPage.pages.forEach((namespace) =>

--- a/src/templates/antora/util.ts
+++ b/src/templates/antora/util.ts
@@ -58,13 +58,13 @@ const generateNavXref = (basePath: string, filename: string, title: string): str
 
 const generateXref = (name: string, structure: ExportStructure): string => {
   const title = getTitleFromFullName(name);
-  const fileName = name.toLowerCase() + '.adoc';
+  const fileName = name.toLowerCase() === 'tinymce' ? getRootPath(structure) : name.toLowerCase();
   switch (structure) {
     case 'legacy':
-      return generateNavXref('api/' + getNamespaceFromFullName(name.toLowerCase()), fileName, title);
+      return generateNavXref('api/' + getNamespaceFromFullName(name.toLowerCase()), fileName + '.adoc', title);
 
     case 'default':
-      return generateNavXref('apis/', fileName, title);
+      return generateNavXref('apis', fileName + '.adoc', title);
   }
 };
 
@@ -83,7 +83,7 @@ const getFilePath = (name: string, structure: ExportStructure): string => {
       return BASE_PATH + '/api/' + folder + '/' + fileName + '.adoc';
 
     case 'default':
-      return BASE_PATH + '/apis/' + fileName + '.adoc';
+      return BASE_PATH + '/' + fileName + '.adoc';
   }
 };
 

--- a/src/templates/antora/util.ts
+++ b/src/templates/antora/util.ts
@@ -204,21 +204,20 @@ const indexToAdoc = (namespace: NavFile, template: HandlebarsTemplateDelegate, d
   ];
   if (namespace.pages) {
     indexPageLines.push(
-      '[cols="1,1"]\n',
-      '|===\n\n',
-      'a|\n\n',
-      '|==='
+      '[cols="1,2",options="header"]\n',
+      '|===\n',
+      '|API|Summary\n\n'
     );
     namespace.pages.forEach((pageFile) => {
       keywords.push(getNameFromFullName(pageFile.title));
       indexPageLines.push('a|\n');
       indexPageLines.push('[.lead]\n');
-      indexPageLines.push(pageFileLine(pageFile, structure) + '\n');
+      indexPageLines.push(pageFileLine(pageFile, structure) + ' |\n');
       const description = descriptions[pageFile.path];
       indexPageLines.push(description + '\n\n');
     });
-
   }
+  indexPageLines.push('|===\n');
   const data = {
     fullName: namespace.title,
     desc: namespaceDescriptions[namespace.title.toLowerCase()],

--- a/src/templates/antora/util.ts
+++ b/src/templates/antora/util.ts
@@ -13,7 +13,7 @@ interface NavFile {
 }
 
 export interface PageOutput {
-  readonly type: 'adoc' | 'json' | 'yml';
+  readonly type: 'adoc' | 'json';
   readonly filename: string;
   readonly content: string;
 }
@@ -73,7 +73,7 @@ const generateTypeXref = (type: string, structure: ExportStructure): string => {
 };
 
 const getJsonFilePath = (type: string, fullName: string): string =>
-  (BASE_PATH + '/api/json/' + type + '_' + fullName.replace(/\./g, '_') + '.json').toLowerCase();
+  ('_data/api/json/' + type + '_' + fullName.replace(/\./g, '_') + '.json').toLowerCase();
 
 const getFilePath = (name: string, structure: ExportStructure): string => {
   const fileName = name.toLowerCase() === 'tinymce' ? getRootPath(structure) : name.toLowerCase();
@@ -227,7 +227,8 @@ const indexToAdoc = (namespace: NavFile, template: HandlebarsTemplateDelegate, d
   return adoc;
 };
 
-const generateIndexPages = (indexPage: NavFile, sortedTypes: Type[], memberTemplate: HandlebarsTemplateDelegate, structure: ExportStructure): PageOutput[] => {
+const generateLegacyIndexPages =
+(indexPage: NavFile, sortedTypes: Type[], memberTemplate: HandlebarsTemplateDelegate, structure: ExportStructure): PageOutput[] => {
   const newNavPages = [] as PageOutput[];
   const descriptions = getDescriptionsFromTypes(sortedTypes);
   indexPage.pages.forEach((namespace) =>
@@ -244,7 +245,7 @@ export {
   compileTemplate,
   getNavFile,
   generateNavPages,
-  generateIndexPages,
+  generateLegacyIndexPages,
   getFilePath,
   getJsonFilePath,
   generateXref,

--- a/src/templates/antora/util.ts
+++ b/src/templates/antora/util.ts
@@ -204,15 +204,14 @@ const indexToAdoc = (namespace: NavFile, template: HandlebarsTemplateDelegate, d
   ];
   if (namespace.pages) {
     indexPageLines.push(
-      '[cols="1,2",options="header"]\n',
-      '|===\n',
-      '|API|Summary\n\n'
+      '[cols="1,1"]\n',
+      '|===\n\n'
     );
     namespace.pages.forEach((pageFile) => {
       keywords.push(getNameFromFullName(pageFile.title));
       indexPageLines.push('a|\n');
       indexPageLines.push('[.lead]\n');
-      indexPageLines.push(pageFileLine(pageFile, structure) + ' |\n');
+      indexPageLines.push(pageFileLine(pageFile, structure) + '\n\n');
       const description = descriptions[pageFile.path];
       indexPageLines.push(description + '\n\n');
     });

--- a/src/templates/antora/util.ts
+++ b/src/templates/antora/util.ts
@@ -1,0 +1,219 @@
+import * as YAML from 'js-yaml';
+
+import { ExportStructure } from '../../lib/exporter';
+import { Type } from '../../lib/type';
+
+interface NavFile {
+  readonly title: string;
+  readonly path: string;
+  readonly pages?: NavFile[];
+}
+
+export interface PageOutput {
+  readonly type: 'adoc' | 'json' | 'yml';
+  readonly filename: string;
+  readonly content: string;
+}
+
+/**
+ * Utility for organising file structure within the antora template.
+ *
+ * @class moxiedoc.antora.Util
+ */
+class Util {
+  private structure: ExportStructure;
+  private BASE_PATH: string;
+
+  /**
+   * Constructs a new Util instance.
+   *
+   * @param
+   * @constructor
+   */
+  public constructor(structure: ExportStructure) {
+    this.structure = structure;
+    this.BASE_PATH = process.env.BASE_PATH || '/_data/antora';
+  }
+
+  public generateNavPages = (sortedTypes: Type[]): PageOutput[] => {
+    const nav = this.getNavFile(sortedTypes);
+    const indexPage = nav[0];
+    const adocNav = this.navToAdoc(indexPage);
+
+    const newNavPages = [] as PageOutput[];
+    newNavPages.push({
+      type: 'adoc',
+      filename: '_data/nav.yml',
+      content: YAML.dump(nav)
+    });
+
+    newNavPages.push({
+      type: 'adoc',
+      filename: '_data/moxiedoc_nav.adoc',
+      content: adocNav
+    });
+
+    switch (this.structure) {
+      case 'legacy':
+        return this.generateIndexPages(newNavPages, indexPage);
+
+      case 'default':
+        return newNavPages;
+    }
+  };
+
+  public getFilePath = (name: string): string => {
+    const fileName = name.toLowerCase() === 'tinymce' ? this.getRootPath() : name.toLowerCase();
+    switch (this.structure) {
+      case 'legacy':
+        const folder = this.getNamespaceFromFullName(name) + '/';
+        return this.BASE_PATH + '/api/' + folder + '/' + fileName + '.adoc';
+
+      case 'default':
+        return this.BASE_PATH + '/apis/' + fileName + '.adoc';
+    }
+  };
+
+  public getJsonFilePath = (type: string, fullName: string): string =>
+    (this.BASE_PATH + '/api/' + type + '_' + fullName.replace(/\./g, '_') + '.json').toLowerCase();
+
+  public generateXref = (name: string): string => {
+    const title = this.getTitleFromFullName(name);
+    return 'xref:' + this.getFilePath(name) + '[' + title + ']';
+  };
+
+  public generateTypeXref = (type: string): string => {
+    return type.includes('tinymce', 0) ? this.generateXref(type) : type;
+  };
+
+  private getNavFile(types: Type[]): NavFile[] {
+    const namespaces = this.getNamespacesFromTypes(types);
+    const pages = Object.entries(namespaces).map(([ url, title ]): NavFile => {
+      const innerPages = types.filter((type) => {
+        const fullName = type.fullName.toLowerCase();
+        return this.getNamespaceFromFullName(fullName) === url;
+      }).map((type): NavFile => {
+        return { title: type.fullName, path: type.fullName.toLowerCase() };
+      });
+
+      if (url === 'tinymce') {
+        innerPages.unshift({
+          title: 'tinymce',
+          path: this.getRootPath()
+        });
+      }
+
+      return {
+        title,
+        path: url,
+        pages: innerPages
+      };
+    });
+
+    return [{
+      title: 'API Reference',
+      path: this.BASE_PATH,
+      pages
+    }];
+  }
+
+  private navToAdoc(indexPage: NavFile): string {
+    // Api index nav page top level
+    let adoc = this.navLine(indexPage.title, 1);
+    if (indexPage.pages) {
+      indexPage.pages.forEach((namespace) => {
+        adoc += this.navLine(this.namespaceLine(namespace), 2);
+        if (namespace.pages) {
+          namespace.pages.forEach((pageFile) => {
+            adoc += this.navLine(this.pageFileLine(pageFile), 3);
+          });
+        }
+      });
+    }
+    return adoc;
+  }
+
+  private generateIndexPages(newNavPages: PageOutput[], indexPage: NavFile): PageOutput[] {
+    indexPage.pages.forEach((namespace) => {
+      newNavPages.push({
+        type: 'adoc',
+        filename: this.BASE_PATH + '/api/' + namespace.path + '/index.adoc',
+        content: this.indexToAdoc(namespace)
+      });
+    });
+    return newNavPages;
+  }
+
+  private indexToAdoc(namespace: NavFile): string {
+    let adoc = '= ' + namespace.title + '\n\n';
+    adoc += '[cols="1,1"]\n';
+    adoc += '|===\n\n';
+    if (namespace.pages) {
+      namespace.pages.forEach((pageFile) => {
+        adoc += 'a|\n';
+        adoc += '[.lead]\n';
+        adoc += this.generateNavXref('api/' + this.getNamespaceFromFullName(namespace.path), pageFile.path + '.adoc', pageFile.title) + '\n\n';
+      });
+    }
+    adoc += 'a|\n\n';
+    adoc += '|===';
+    return adoc;
+  }
+
+  private getNamespacesFromTypes(types: Type[]): Record<string, string> {
+    return types.reduce((namespaces: Record<string, string>, type: Type) => {
+      const fullName = type.fullName.toLowerCase();
+      const url = this.getNamespaceFromFullName(fullName);
+      if (url && !namespaces[url]) {
+        namespaces[url] = this.getNamespaceFromFullName(type.fullName);
+      }
+      return namespaces;
+    }, {});
+  }
+
+  private getRootPath(): string {
+    switch (this.structure) {
+      case 'legacy':
+        return 'tinymce.root_tinymce';
+
+      case 'default':
+        return 'tinymce.root';
+    }
+  }
+
+  private namespaceLine(namespace: NavFile): string {
+    switch (this.structure) {
+      case 'legacy':
+        return this.generateNavXref('api/' + namespace.path, 'index.adoc', namespace.title);
+
+      case 'default':
+        return namespace.title;
+    }
+  }
+
+  private pageFileLine(pageFile: NavFile): string {
+    switch (this.structure) {
+      case 'legacy':
+        return this.generateNavXref('api/' + this.getNamespaceFromFullName(pageFile.path), pageFile.path + '.adoc', pageFile.title);
+
+      case 'default':
+        return this.generateNavXref('apis', pageFile.path + '.adoc', pageFile.title);
+    }
+  }
+
+  private getNamespaceFromFullName = (fullName: string): string =>
+    fullName.split('.').slice(0, -1).join('.');
+
+  private getTitleFromFullName = (fullName: string): string =>
+    fullName.split('.').slice(-1).join('');
+
+  private generateNavXref = (basePath: string, filename: string, title: string): string =>
+    'xref:' + basePath + '/' + filename + '[' + title + ']';
+
+  private navLine = (name: string, level: number): string =>
+    '*'.repeat(level) + ' ' + name + '\n';
+}
+
+export {
+  Util
+};


### PR DESCRIPTION
Related Ticket: TINY-8747

Description of Changes:
* Added `structure` option with default value `flat` for all files output to same folder, or `legacy` for nested folder output

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)
