### PR TITLE
TINY-8747: Added file structure option to support legacy output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.3.0 - 2022-08-23
+
+### Added
+- New `structure` option for specifying `legacy` nested structure for antora docs.
+
 ## 0.2.1 - 2022-04-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,36 @@
 # moxiedoc
 
+## Introduction
+
+This project maintains Moxiedoc, a tool used to build API reference documentation. If you have any modifications you wish to contribute, fork this project, make the changes and submit a pull request. You will need to sign the contributors license agreement, which will be emailed to you upon creating the pull request.
+
+## Using Moxiedoc
+
+To create API reference documentation from a development version of moxiedoc, run:
+
+```
+yarn build
+node ./dist/lib/cli.js PATH/TO/API_FILE_FOLDER
+```
+
+## Moxiedoc Options
+
+Moxiedoc provides the following options to customise the format of the output documentation:
+
+```
+-o --out <path>: location of output files, default: 'tmp/out.zip'
+-t --template <template>: documentation type: default: 'cli'; 'antora', 'github', 'moxiewiki', 'singlehtml', 'tinymcenext', 'xml'
+-s --structure <type>: default: 'default'; 'legacy'
+-v --verbose: verbose output
+--debug: debug output
+--dry: dry run only syntax check
+--fail-on-warning: fail if warnings are produced
+```
+
+## Schema
+
+The output JSON takes the form of the following schema:
+
 ```json
 {
   "namespace.Class": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/moxiedoc",
-  "version": "0.2.2-rc",
+  "version": "0.3.0-rc",
   "description": "A tool for generating API documentation",
   "author": "Tiny Technologies, Inc",
   "bugs": {

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -8,10 +8,11 @@ import { MoxiedocSettings, process as moxieDocProcess } from './moxiedoc';
 process.argv[1] = 'moxiedoc';
 
 program
-  .version('0.2.0')
+  .version('0.3.0')
   .usage('[options] <dir ...>')
   .option('-o, --out <path>', 'output path, default: out')
-  .option('-t, --template <template>', 'template name')
+  .option('-t, --template <template>', 'template name, default: cli')
+  .option('-s, --structure <type>', 'output file structure, default: default')
   .option('-v, --verbose', 'verbose output')
   .option('--debug', 'debug output')
   .option('--dry', 'dry run only syntax check')

--- a/src/lib/exporter.ts
+++ b/src/lib/exporter.ts
@@ -1,7 +1,10 @@
 import { Api } from './api';
 
+export type ExportStructure = 'default' | 'legacy';
+
 export interface ExporterSettings {
   readonly template: string;
+  readonly structure: ExportStructure;
 }
 
 /**
@@ -25,7 +28,7 @@ class Exporter {
     const templatePath = '../templates/' + this.settings.template + '/template.js';
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    require(templatePath).template.call(this, types, dirPath);
+    require(templatePath).template.call(this, types, dirPath, this.settings.structure);
   }
 }
 

--- a/src/lib/moxiedoc.ts
+++ b/src/lib/moxiedoc.ts
@@ -3,7 +3,7 @@ import * as matcher from 'matcher';
 import * as path from 'path';
 
 import { Builder } from './builder';
-import { Exporter } from './exporter';
+import { Exporter, ExportStructure } from './exporter';
 import * as Reporter from './reporter';
 
 exports.Builder = Builder;
@@ -12,6 +12,7 @@ exports.Exporter = Exporter;
 export interface MoxiedocSettings {
   out?: string;
   template?: string;
+  structure?: ExportStructure;
   verbose?: boolean;
   debug?: boolean;
   paths: string[];
@@ -44,6 +45,7 @@ export interface MoxiedocResult {
 const process = (settings: MoxiedocSettings): MoxiedocResult => {
   settings.out = settings.out || 'tmp/out.zip';
   settings.template = settings.template || 'cli';
+  settings.structure = settings.structure || 'default';
 
   if (settings.verbose) {
     Reporter.setLevel(Reporter.Level.INFO);
@@ -99,7 +101,8 @@ const process = (settings: MoxiedocSettings): MoxiedocResult => {
 
   if (!settings.dry) {
     const exporter = new Exporter({
-      template: settings.template
+      template: settings.template,
+      structure: settings.structure
     });
 
     exporter.exportTo(builder.api, settings.out);

--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -1,14 +1,10 @@
+
+import { ExportStructure } from 'src/lib/exporter';
+
 import { Return } from '../../lib/member';
 import { Param } from '../../lib/param';
-
-export interface PageOutput {
-  readonly type: 'adoc' | 'json';
-  readonly filename: string;
-  readonly content: string;
-}
-
-// TODO: we can pass this through later
-const basePath = 'apis/';
+import { PageOutput } from './util';
+import * as Util from './util';
 
 const hasValue = <T>(x: T): x is NonNullable<T> => {
   // empty helper for strings, objects, arrays
@@ -79,20 +75,6 @@ const cleanup = (str: string): string => {
   return filters.reduce((acc, filter) => filter(acc), str);
 };
 
-const getNameFromFullName = (name: string): string =>
-  name.split('.').slice(-1).join('');
-
-const getFilePathFromFullName = (name: string): string => {
-  const filename = name.toLowerCase() === 'tinymce' ? 'tinymce.root' : name.toLowerCase();
-  return basePath + filename + '.adoc';
-};
-
-const generateTypeXref = (type: string): string =>
-  type.includes('tinymce', 0) ? 'xref:' + getFilePathFromFullName(type) + '[' + getNameFromFullName(type) + ']' : type;
-
-const generateDefinedByXref = (definedBy: string): string =>
-  'xref:' + getFilePathFromFullName(definedBy) + '[' + getNameFromFullName(definedBy) + ']';
-
 const generateExamples = (examples: Array<{ content: string }>): string => {
   let tmp = '\n==== Examples\n';
   examples.forEach((example) => {
@@ -104,24 +86,23 @@ const generateExamples = (examples: Array<{ content: string }>): string => {
   return tmp;
 };
 
-const generateParameters = (params: Param[]): string => {
+const generateParameters = (params: Param[], structure: ExportStructure): string => {
   let tmp = '\n==== Parameters\n';
   params.forEach((param) => {
-    tmp += '\n* `' + param.name + ' (' + param.types.map(generateTypeXref).join(' | ') + ')` - ' + cleanup(param.desc);
+    tmp += '\n* `' + param.name + ' (' + param.types.map((type) => Util.generateTypeXref(type, structure)).join(' | ') + ')` - ' + cleanup(param.desc);
   });
   return tmp + '\n';
 };
 
-const generateReturn = (ret: Return): string => {
+const generateReturn = (ret: Return, structure: ExportStructure): string => {
   let tmp = '\n==== Return value\n';
   ret.types.forEach((type) => {
-    tmp += '\n* `' + generateTypeXref(type) + '` - ' + cleanup(ret.desc);
+    tmp += '\n* `' + Util.generateTypeXref(type, structure) + '` - ' + cleanup(ret.desc);
   });
-  tmp += '\n';
-  return tmp;
+  return tmp += '\n';
 };
 
-const buildSummary = (data: Record<string, any>): string => {
+const buildSummary = (data: Record<string, any>, structure: ExportStructure): string => {
   let tmp = '';
 
   // settings
@@ -136,9 +117,9 @@ const buildSummary = (data: Record<string, any>): string => {
 
     data.settings.forEach((item) => {
       tmp += '|' + item.name;
-      tmp += '|`' + generateTypeXref(item.dataTypes[0]) + '`';
+      tmp += '|`' + Util.generateTypeXref(item.dataTypes[0], structure) + '`';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + generateDefinedByXref(item.definedBy) + '`\n';
+      tmp += '|`' + Util.generateXref(item.definedBy, structure) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -154,9 +135,9 @@ const buildSummary = (data: Record<string, any>): string => {
 
     data.properties.forEach((item) => {
       tmp += '|' + item.name;
-      tmp += '|`' + generateTypeXref(item.dataTypes[0]) + '`';
+      tmp += '|`' + Util.generateTypeXref(item.dataTypes[0], structure) + '`';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + generateDefinedByXref(item.definedBy) + '`\n';
+      tmp += '|`' + Util.generateXref(item.definedBy, structure) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -173,7 +154,7 @@ const buildSummary = (data: Record<string, any>): string => {
     data.constructors.forEach((item) => {
       tmp += '|xref:#' + item.name + '[' + item.name + '()]';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + generateDefinedByXref(item.definedBy) + '`\n';
+      tmp += '|`' + Util.generateXref(item.definedBy, structure) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -186,7 +167,7 @@ const buildSummary = (data: Record<string, any>): string => {
     tmp += '|===\n';
     tmp += '|Name|Summary|Defined by\n';
     data.methods.forEach((item) => {
-      tmp += '|xref:#' + item.name + '[' + item.name + '()]|' + cleanup(item.desc) + '|`' + generateDefinedByXref(item.definedBy) + '`\n';
+      tmp += '|xref:#' + item.name + '[' + item.name + '()]|' + cleanup(item.desc) + '|`' + Util.generateXref(item.definedBy, structure) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -204,7 +185,7 @@ const buildSummary = (data: Record<string, any>): string => {
     data.events.forEach((item) => {
       tmp += '|xref:#' + item.name + '[' + item.name + ']';
       tmp += '|' + cleanup(item.desc);
-      tmp += '|`' + generateDefinedByXref(item.definedBy) + '`\n';
+      tmp += '|`' + Util.generateXref(item.definedBy, structure) + '`\n';
     });
     tmp += '|===\n';
   }
@@ -212,7 +193,7 @@ const buildSummary = (data: Record<string, any>): string => {
   return tmp.length > 0 ? '\n[[summary]]\n== Summary\n' + tmp : tmp;
 };
 
-const buildConstructor = (data: Record<string, any>): string => {
+const buildConstructor = (data: Record<string, any>, structure: ExportStructure): string => {
   let tmp = '';
 
   if (hasValue(data.constructors)) {
@@ -233,11 +214,11 @@ const buildConstructor = (data: Record<string, any>): string => {
       }
 
       if (hasValue(constructor.params)) {
-        tmp += generateParameters(constructor.params);
+        tmp += generateParameters(constructor.params, structure);
       }
 
       if (hasValue(constructor.return) && hasValue(constructor.return.types)) {
-        tmp += generateReturn(constructor.return);
+        tmp += generateReturn(constructor.return, structure);
       }
     });
   }
@@ -245,7 +226,7 @@ const buildConstructor = (data: Record<string, any>): string => {
   return tmp;
 };
 
-const buildMethods = (data: Record<string, any>): string => {
+const buildMethods = (data: Record<string, any>, structure: ExportStructure): string => {
   let tmp = '';
 
   if (hasValue(data.methods)) {
@@ -265,11 +246,11 @@ const buildMethods = (data: Record<string, any>): string => {
       }
 
       if (hasValue(method.params)) {
-        tmp += generateParameters(method.params);
+        tmp += generateParameters(method.params, structure);
       }
 
       if (hasValue(method.return) && hasValue(method.return.types)) {
-        tmp += generateReturn(method.return);
+        tmp += generateReturn(method.return, structure);
       }
 
       tmp += `\n'''\n`;
@@ -279,7 +260,7 @@ const buildMethods = (data: Record<string, any>): string => {
   return tmp;
 };
 
-const buildEvents = (data: Record<string, any>): string => {
+const buildEvents = (data: Record<string, any>, structure: ExportStructure): string => {
   let tmp = '';
 
   // untested snippet, no events data
@@ -292,7 +273,7 @@ const buildEvents = (data: Record<string, any>): string => {
       tmp += cleanup(event.desc) + '\n';
 
       if (hasValue(event.params)) {
-        tmp += generateParameters(event.params);
+        tmp += generateParameters(event.params, structure);
       }
     });
   }
@@ -300,7 +281,7 @@ const buildEvents = (data: Record<string, any>): string => {
   return tmp;
 };
 
-const convert = (pages: PageOutput[][]): PageOutput[][] => pages.map((page) => {
+const convert = (pages: PageOutput[][], structure: ExportStructure): PageOutput[][] => pages.map((page) => {
   // page[0] is json
   // page[1] is adoc
   const data = JSON.parse(page[0].content);
@@ -334,7 +315,7 @@ const convert = (pages: PageOutput[][]): PageOutput[][] => pages.map((page) => {
     tmp += '\n[[extends]]\n';
     tmp += '== Extends\n';
     data.borrows.forEach((item) => {
-      tmp += '\n * xref:' + basePath + item.toLowerCase() + '.adoc[' + item + ']\n';
+      tmp += '\n * ' + Util.generateXref(item, structure) + '\n';
     });
   }
 
@@ -350,10 +331,10 @@ const convert = (pages: PageOutput[][]): PageOutput[][] => pages.map((page) => {
     });
   }
 
-  tmp += buildSummary(data);
-  tmp += buildConstructor(data);
-  tmp += buildMethods(data);
-  tmp += buildEvents(data);
+  tmp += buildSummary(data, structure);
+  tmp += buildConstructor(data, structure);
+  tmp += buildMethods(data, structure);
+  tmp += buildEvents(data, structure);
 
   // return the applied antora page mutation
   page[1] = {

--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -1,6 +1,5 @@
 
-import { ExportStructure } from 'src/lib/exporter';
-
+import { ExportStructure } from '../../lib/exporter';
 import { Return } from '../../lib/member';
 import { Param } from '../../lib/param';
 import { PageOutput } from './util';

--- a/src/templates/antora/template.ts
+++ b/src/templates/antora/template.ts
@@ -1,7 +1,8 @@
 import { ZipWriter } from 'moxie-zip';
-import { ExportStructure } from 'src/lib/exporter';
 
 import { Api } from '../../lib/api';
+import { ExportStructure } from '../../lib/exporter';
+import * as Reporter from '../../lib/reporter';
 import { Type } from '../../lib/type';
 import * as AntoraTemplate from './antora.converter';
 import { PageOutput } from './util';
@@ -120,6 +121,7 @@ const flatten = <T>(array: T[][]): T[] => {
  * @param {[type]} page [description]
  */
 const addPageToArchive = function (this: ZipWriter, page: PageOutput) {
+  Reporter.info('Adding file to zip:', page.filename);
   this.addData(page.filename, page.content);
 };
 

--- a/src/templates/antora/template.ts
+++ b/src/templates/antora/template.ts
@@ -1,92 +1,11 @@
-import * as fs from 'fs';
-import * as Handlebars from 'handlebars';
-import * as YAML from 'js-yaml';
 import { ZipWriter } from 'moxie-zip';
-import * as path from 'path';
+import { ExportStructure } from 'src/lib/exporter';
 
 import { Api } from '../../lib/api';
 import { Type } from '../../lib/type';
 import * as AntoraTemplate from './antora.converter';
-
-interface NavFile {
-  readonly title: string;
-  readonly path: string;
-  readonly pages?: NavFile[];
-}
-
-type PageOutput = AntoraTemplate.PageOutput;
-
-const BASE_PATH = process.env.BASE_PATH || '/_data/antora';
-
-// correlates to tinymce-docs antora path
-const AntoraNavBaseDir = 'apis/';
-
-const navToAdoc = (navyml: NavFile[]): string => {
-  // Api index page
-  const indexPage = navyml[0];
-  let adoc = '* ' + indexPage.title + '\n';
-
-  // generate API namespaces
-  indexPage.pages.forEach((namespace) => {
-    // main namespace level navigation (namespace index)
-    adoc += '** ' + namespace.path + '\n';
-    namespace.pages.forEach((page) => {
-      // namespace level pages
-      adoc += '*** xref:' + AntoraNavBaseDir + page.path + '.adoc' + '[' + page.title + ']\n';
-    });
-  });
-
-  return adoc;
-};
-
-const getNamespaceFromFullName = (fullName: string) =>
-  fullName.split('.').slice(0, -1).join('.');
-
-const getNamespacesFromTypes = (types: Type[]): Record<string, string> => {
-  return types.reduce((namespaces: Record<string, string>, type: Type) => {
-    const fullName = type.fullName.toLowerCase();
-    const url = getNamespaceFromFullName(fullName);
-    if (url && !namespaces[url]) {
-      namespaces[url] = getNamespaceFromFullName(type.fullName);
-    }
-    return namespaces;
-  }, {});
-};
-
-/**
- * [getNavFile description]
- * @return {[type]} [description]
- */
-const getNavFile = (types: Type[]): NavFile[] => {
-  const namespaces = getNamespacesFromTypes(types);
-  const pages = Object.entries(namespaces).map(([ url, title ]): NavFile => {
-    const innerPages = types.filter((type) => {
-      const fullName = type.fullName.toLowerCase();
-      return getNamespaceFromFullName(fullName) === url;
-    }).map((type): NavFile => {
-      return { title: type.fullName, path: type.fullName.toLowerCase() };
-    });
-
-    if (url === 'tinymce') {
-      innerPages.unshift({
-        title: 'tinymce',
-        path: 'tinymce.root'
-      });
-    }
-
-    return {
-      title,
-      path: url,
-      pages: innerPages
-    };
-  });
-
-  return [{
-    title: 'API Reference',
-    path: BASE_PATH,
-    pages
-  }];
-};
+import { PageOutput } from './util';
+import * as Util from './util';
 
 /**
  * [description]
@@ -95,7 +14,7 @@ const getNavFile = (types: Type[]): NavFile[] => {
  * @param  {[type]} type [description]
  * @return {[type]}      [description]
  */
-const getMemberPages = (root: Api, templateDelegate: HandlebarsTemplateDelegate, type: Type): PageOutput[] => {
+const getMemberPages = (root: Api, templateDelegate: HandlebarsTemplateDelegate, structure: ExportStructure, type: Type): PageOutput[] => {
   const members = type.getMembers(true);
   const data = type.toJSON();
   data.datapath = data.type + '_' + data.fullName.replace(/\./g, '_').toLowerCase();
@@ -119,36 +38,32 @@ const getMemberPages = (root: Api, templateDelegate: HandlebarsTemplateDelegate,
 
   members.forEach((member) => {
     const parentType = member.getParentType();
-
     const memberData = member.toJSON();
     data.keywords.push(memberData.name);
     memberData.definedBy = parentType.fullName;
 
-    if ('property' === memberData.type) {
-      data.properties.push(memberData);
-      return;
-    }
+    switch (memberData.type) {
+      case 'property':
+        data.properties.push(memberData);
+        return;
 
-    if ('setting' === memberData.type) {
-      data.settings.push(memberData);
-      return;
-    }
+      case 'setting':
+        data.settings.push(memberData);
+        return;
 
-    if ('constructor' === memberData.type) {
-      data.constructors.push(memberData);
-      memberData.signature = getSyntaxString(memberData);
-      return;
-    }
+      case 'constructor':
+        data.constructors.push(memberData);
+        memberData.signature = getSyntaxString(memberData);
+        return;
 
-    if ('method' === memberData.type) {
-      data.methods.push(memberData);
-      memberData.signature = getSyntaxString(memberData);
-      return;
-    }
+      case 'method':
+        data.methods.push(memberData);
+        memberData.signature = getSyntaxString(memberData);
+        return;
 
-    if ('event' === memberData.type) {
-      data.events.push(memberData);
-      return;
+      case 'event':
+        data.events.push(memberData);
+        return;
     }
   });
 
@@ -160,13 +75,16 @@ const getMemberPages = (root: Api, templateDelegate: HandlebarsTemplateDelegate,
   data.keywords = sortMembers(data.keywords);
 
   data.keywords = data.keywords.join(', ');
+
+  const jsonFilePath = Util.getJsonFilePath(data.type, data.fullName);
+  const adocFilePath = Util.getFilePath(data.fullName, structure);
   return [{
     type: 'json',
-    filename: createFileName(data, 'json'),
+    filename: jsonFilePath,
     content: JSON.stringify(data, null, '  ')
   }, {
     type: 'adoc',
-    filename: createFileName(data, 'adoc'),
+    filename: adocFilePath,
     content: templateDelegate(data)
   }];
 };
@@ -198,37 +116,10 @@ const flatten = <T>(array: T[][]): T[] => {
 };
 
 /**
- * [compileTemplate description]
- * @param  {[type]} filePath [description]
- * @return {[type]}          [description]
- */
-const compileTemplate = (filePath: string): HandlebarsTemplateDelegate => {
-  return Handlebars.compile(fs.readFileSync(path.join(__dirname, filePath)).toString());
-};
-
-/**
- * [createFileName description]
- * @param  {[type]} data [description]
- * @param  {[type]} ext [description]
- * @return {[type]}          [description]
- */
-const createFileName = (data: Record<string, any>, ext: 'adoc' | 'json'): string => {
-  if ('adoc' === ext) {
-    if (data.fullName === 'tinymce') {
-      return (BASE_PATH + '/tinymce.root.adoc').toLowerCase();
-    }
-
-    return (BASE_PATH + '/' + data.fullName + '.adoc').toLowerCase();
-  } else if ('json' === ext) {
-    return ('_data/api/' + data.type + '_' + data.fullName.replace(/\./g, '_') + '.json').toLowerCase();
-  }
-};
-
-/**
  * [addPageToArchive description]
  * @param {[type]} page [description]
  */
-const addPageToArchive = function (this: ZipWriter, page: { filename: string; content: string }) {
+const addPageToArchive = function (this: ZipWriter, page: PageOutput) {
   this.addData(page.filename, page.content);
 };
 
@@ -266,11 +157,12 @@ const getSyntaxString = (memberData: Record<string, any>) => {
  * [function description]
  * @param  {[type]} root   [description]
  * @param  {[type]} toPath [description]
+ * @param  {[type]} structure [description]
  * @return {[type]}        [description]
  */
-const template = (root: Api, toPath: string): void => {
+const template = (root: Api, toPath: string, structure: ExportStructure): void => {
   const archive = new ZipWriter();
-  const memberTemplate = compileTemplate('member.handlebars');
+  const memberTemplate = Util.compileTemplate('member.handlebars');
 
   // bind new archive to function
   const addPage = addPageToArchive.bind(archive);
@@ -286,22 +178,21 @@ const template = (root: Api, toPath: string): void => {
     }
   });
 
-  const nav = getNavFile(sortedTypes);
-  const adocNav = navToAdoc(nav);
+  const indexPage = Util.getNavFile(sortedTypes);
 
-  addPage({
-    filename: '_data/nav.yml',
-    content: YAML.dump(nav)
-  });
+  const navPages = Util.generateNavPages(indexPage, structure);
 
-  addPage({
-    filename: '_data/moxiedoc_nav.adoc',
-    content: adocNav
-  });
+  if (structure === 'legacy') {
+    Util.generateLegacyIndexPages(indexPage, sortedTypes, memberTemplate, structure)
+      .forEach((pageOutput) => navPages.push(pageOutput));
+  }
+
+  navPages.forEach(addPage);
 
   // create all json and adoc for each item
-  const pages: PageOutput[][] = sortedTypes.map(getMemberPages.bind(null, root, memberTemplate));
-  const convertedPages = AntoraTemplate.convert(pages);
+  const pages: PageOutput[][] = sortedTypes.map(getMemberPages.bind(null, root, memberTemplate, structure));
+
+  const convertedPages = AntoraTemplate.convert(pages, structure);
   flatten(convertedPages).forEach(addPage);
 
   archive.saveAs(toPath, (err) => {

--- a/src/templates/antora/util.ts
+++ b/src/templates/antora/util.ts
@@ -51,20 +51,20 @@ const getTitleFromFullName = (fullName: string): string =>
   fullName.split('.').slice(-1).join('');
 
 const navLine = (name: string, level: number): string =>
-  '*'.repeat(level) + ' ' + name + '\n';
+  '*'.repeat(level) + ` ${name}\n`;
 
 const generateNavXref = (basePath: string, filename: string, title: string): string =>
-  'xref:' + basePath + '/' + filename + '[' + title + ']';
+  `xref:${basePath}/${filename}[${title}]`;
 
 const generateXref = (name: string, structure: ExportStructure): string => {
   const title = getTitleFromFullName(name);
   const fileName = name.toLowerCase() === 'tinymce' ? getRootPath(structure) : name.toLowerCase();
   switch (structure) {
     case 'legacy':
-      return generateNavXref('api/' + getNamespaceFromFullName(name.toLowerCase()), fileName + '.adoc', title);
+      return generateNavXref(`api/${getNamespaceFromFullName(name.toLowerCase())}`, `${fileName}.adoc`, title);
 
     case 'default':
-      return generateNavXref('apis', fileName + '.adoc', title);
+      return generateNavXref('apis', `${fileName}.adoc`, title);
   }
 };
 
@@ -73,24 +73,24 @@ const generateTypeXref = (type: string, structure: ExportStructure): string => {
 };
 
 const getJsonFilePath = (type: string, fullName: string): string =>
-  ('_data/api/json/' + type + '_' + fullName.replace(/\./g, '_') + '.json').toLowerCase();
+  (`_data/api/json/${type}_${fullName.replace(/\./g, '_')}.json`).toLowerCase();
 
 const getFilePath = (name: string, structure: ExportStructure): string => {
   const fileName = name.toLowerCase() === 'tinymce' ? getRootPath(structure) : name.toLowerCase();
   switch (structure) {
     case 'legacy':
-      const folder = getNamespaceFromFullName(name) + '/';
-      return BASE_PATH + '/api/' + folder + '/' + fileName + '.adoc';
+      const folder = getNamespaceFromFullName(name);
+      return `${BASE_PATH}/api/${folder}/${fileName}.adoc`;
 
     case 'default':
-      return BASE_PATH + '/' + fileName + '.adoc';
+      return `${BASE_PATH}/${fileName}.adoc`;
   }
 };
 
 const namespaceNavLine = (namespace: NavFile, structure: ExportStructure): string => {
   switch (structure) {
     case 'legacy':
-      return generateNavXref('api/' + namespace.path, 'index.adoc', namespace.title);
+      return generateNavXref(`api/${namespace.path}`, 'index.adoc', namespace.title);
 
     case 'default':
       return namespace.title;
@@ -102,7 +102,7 @@ const pageFileNavLine = (pageFile: NavFile, structure: ExportStructure): string 
   switch (structure) {
     case 'legacy':
       const folder = getNamespaceFromFullName(pageFile.path);
-      return generateNavXref('api/' + folder, fileName, pageFile.title);
+      return generateNavXref(`api/${folder}`, fileName, pageFile.title);
 
     case 'default':
       return generateNavXref('apis', fileName, pageFile.title);
@@ -112,7 +112,7 @@ const pageFileNavLine = (pageFile: NavFile, structure: ExportStructure): string 
 const pageFileLegacyIndexLine = (pageFile: NavFile, structure: ExportStructure): string => {
   const fileName = (pageFile.path === 'tinymce' ? getRootPath(structure) : pageFile.path) + '.adoc';
   const folder = getNamespaceFromFullName(pageFile.path);
-  return generateNavXref('api/' + folder, fileName, getNameFromFullName(pageFile.title));
+  return generateNavXref(`api/${folder}`, fileName, getNameFromFullName(pageFile.title));
 };
 
 const getRootPath = (structure: ExportStructure): string => {
@@ -251,7 +251,7 @@ const generateLegacyIndexPages = (
   indexPage.pages.forEach((namespace) =>
     newNavPages.push({
       type: 'adoc',
-      filename: BASE_PATH + '/api/' + namespace.path + '/index.adoc',
+      filename: `${BASE_PATH}/api/${namespace.path}/index.adoc`,
       content: legacyIndexToAdoc(namespace, memberTemplate, descriptions, structure)
     })
   );

--- a/src/templates/antora/util.ts
+++ b/src/templates/antora/util.ts
@@ -1,0 +1,270 @@
+import * as fs from 'fs';
+import * as Handlebars from 'handlebars';
+import * as YAML from 'js-yaml';
+import * as path from 'path';
+
+import { ExportStructure } from '../../lib/exporter';
+import { Type } from '../../lib/type';
+
+interface NavFile {
+  readonly title: string;
+  readonly path: string;
+  readonly pages?: NavFile[];
+}
+
+export interface PageOutput {
+  readonly type: 'adoc' | 'json';
+  readonly filename: string;
+  readonly content: string;
+}
+
+const BASE_PATH: string = process.env.BASE_PATH || '/_data/antora';
+
+const namespaceDescriptions = {
+  'tinymce': 'Global APIs for working with the editor.',
+  'tinymce.dom': 'APIs for working with the DOM from within the editor.',
+  'tinymce.editor.ui': 'APIs for registering User Interface components.',
+  'tinymce.geom': 'Various rectangle APIs.',
+  'tinymce.html': 'APIs for working with HTML within the editor.',
+  'tinymce.util': 'Browser related APIs.'
+};
+
+/**
+ * [compileTemplate description]
+ * @param  {[type]} filePath [description]
+ * @return {[type]}          [description]
+ */
+const compileTemplate = (filePath: string): HandlebarsTemplateDelegate => {
+  return Handlebars.compile(fs.readFileSync(path.join(__dirname, filePath)).toString());
+};
+
+const getNamespaceFromFullName = (fullName: string): string =>
+  fullName === 'tinymce' ? fullName : fullName.split('.').slice(0, -1).join('.');
+
+const getApiFromFullName = (fullName: string): string =>
+  fullName === 'tinymce' ? fullName : fullName.split('.').slice(1).join('.');
+
+const getNameFromFullName = (fullName: string): string =>
+  fullName === 'tinymce' ? fullName : fullName.split('.').slice(-1).join('.');
+
+const getTitleFromFullName = (fullName: string): string =>
+  fullName.split('.').slice(-1).join('');
+
+const navLine = (name: string, level: number): string =>
+  '*'.repeat(level) + ' ' + name + '\n';
+
+const generateNavXref = (basePath: string, filename: string, title: string): string =>
+  'xref:' + basePath + '/' + filename + '[' + title + ']';
+
+const generateXref = (name: string, structure: ExportStructure): string => {
+  const title = getTitleFromFullName(name);
+  const fileName = name.toLowerCase() === 'tinymce' ? getRootPath(structure) : name.toLowerCase();
+  switch (structure) {
+    case 'legacy':
+      return generateNavXref('api/' + getNamespaceFromFullName(name.toLowerCase()), fileName + '.adoc', title);
+
+    case 'default':
+      return generateNavXref('apis', fileName + '.adoc', title);
+  }
+};
+
+const generateTypeXref = (type: string, structure: ExportStructure): string => {
+  return type.includes('tinymce', 0) ? generateXref(type, structure) : type;
+};
+
+const getJsonFilePath = (type: string, fullName: string): string =>
+  ('_data/api/json/' + type + '_' + fullName.replace(/\./g, '_') + '.json').toLowerCase();
+
+const getFilePath = (name: string, structure: ExportStructure): string => {
+  const fileName = name.toLowerCase() === 'tinymce' ? getRootPath(structure) : name.toLowerCase();
+  switch (structure) {
+    case 'legacy':
+      const folder = getNamespaceFromFullName(name) + '/';
+      return BASE_PATH + '/api/' + folder + '/' + fileName + '.adoc';
+
+    case 'default':
+      return BASE_PATH + '/' + fileName + '.adoc';
+  }
+};
+
+const namespaceNavLine = (namespace: NavFile, structure: ExportStructure): string => {
+  switch (structure) {
+    case 'legacy':
+      return generateNavXref('api/' + namespace.path, 'index.adoc', namespace.title);
+
+    case 'default':
+      return namespace.title;
+  }
+};
+
+const pageFileNavLine = (pageFile: NavFile, structure: ExportStructure): string => {
+  const fileName = (pageFile.path === 'tinymce' ? getRootPath(structure) : pageFile.path) + '.adoc';
+  switch (structure) {
+    case 'legacy':
+      const folder = getNamespaceFromFullName(pageFile.path);
+      return generateNavXref('api/' + folder, fileName, pageFile.title);
+
+    case 'default':
+      return generateNavXref('apis', fileName, pageFile.title);
+  }
+};
+
+const pageFileLegacyIndexLine = (pageFile: NavFile, structure: ExportStructure): string => {
+  const fileName = (pageFile.path === 'tinymce' ? getRootPath(structure) : pageFile.path) + '.adoc';
+  const folder = getNamespaceFromFullName(pageFile.path);
+  return generateNavXref('api/' + folder, fileName, getNameFromFullName(pageFile.title));
+};
+
+const getRootPath = (structure: ExportStructure): string => {
+  switch (structure) {
+    case 'legacy':
+      return 'root_tinymce';
+
+    case 'default':
+      return 'tinymce.root';
+  }
+};
+
+const getNamespacesFromTypes = (types: Type[]): Record<string, string> => {
+  return types.reduce((namespaces: Record<string, string>, type: Type) => {
+    const fullName = type.fullName.toLowerCase();
+    const url = getNamespaceFromFullName(fullName);
+    if (url && !namespaces[url]) {
+      namespaces[url] = getNamespaceFromFullName(type.fullName);
+    }
+    return namespaces;
+  }, {});
+};
+
+const getDescriptionsFromTypes = (types: Type[]): Record<string, string> => {
+  return types.reduce((descriptions: Record<string, string>, type: Type) => {
+    const name = type.fullName.toLowerCase();
+    if (name && !descriptions[name]) {
+      descriptions[name] = type.desc;
+    }
+    return descriptions;
+  }, {});
+};
+
+const getNavFile = (types: Type[]): NavFile => {
+  const namespaces = getNamespacesFromTypes(types);
+  const pages = Object.entries(namespaces).map(([ url, title ]): NavFile => {
+    const innerPages = types.filter((type) => {
+      const fullName = type.fullName.toLowerCase();
+      return getNamespaceFromFullName(fullName) === url;
+    }).map((type): NavFile => {
+      return { title: type.fullName, path: type.fullName.toLowerCase() };
+    });
+
+    return {
+      title,
+      path: url,
+      pages: innerPages
+    };
+  });
+
+  return {
+    title: 'API Reference',
+    path: BASE_PATH,
+    pages
+  };
+};
+
+const navToAdoc = (indexPage: NavFile, structure: ExportStructure): string => {
+  // Api index nav page top level
+  let adoc = navLine(indexPage.title, 1);
+  if (indexPage.pages) {
+    indexPage.pages.forEach((namespace) => {
+      adoc += navLine(namespaceNavLine(namespace, structure), 2);
+      if (namespace.pages) {
+        namespace.pages.forEach((pageFile) => {
+          adoc += navLine(pageFileNavLine(pageFile, structure), 3);
+        });
+      }
+    });
+  }
+  return adoc;
+};
+
+const generateNavPages = (indexPage: NavFile, structure: ExportStructure): PageOutput[] => {
+  const navPages = [] as PageOutput[];
+  navPages.push({
+    type: 'adoc',
+    filename: '_data/nav.yml',
+    content: YAML.dump(indexPage)
+  });
+
+  const adocNav = navToAdoc(indexPage, structure);
+  navPages.push({
+    type: 'adoc',
+    filename: '_data/moxiedoc_nav.adoc',
+    content: adocNav
+  });
+  return navPages;
+};
+
+const legacyIndexToAdoc = (
+  namespace: NavFile,
+  template: HandlebarsTemplateDelegate,
+  descriptions: Record<string, string>,
+  structure: ExportStructure
+): string => {
+  const keywords = [ getApiFromFullName(namespace.title) ];
+  const indexPageLines = [
+    '\n== ' + namespaceDescriptions[namespace.title.toLowerCase()] + '\n\n'
+  ];
+  if (namespace.pages) {
+    indexPageLines.push(
+      '[cols="1,1"]\n',
+      '|===\n\n'
+    );
+    namespace.pages.forEach((pageFile) => {
+      keywords.push(getNameFromFullName(pageFile.title));
+      indexPageLines.push('a|\n');
+      indexPageLines.push('[.lead]\n');
+      indexPageLines.push(pageFileLegacyIndexLine(pageFile, structure) + '\n\n');
+      const description = descriptions[pageFile.path];
+      indexPageLines.push(description + '\n\n');
+    });
+    if (namespace.pages.length % 2 !== 0) {
+      indexPageLines.push('a|\n');
+    }
+    indexPageLines.push('|===\n');
+  }
+  const data = {
+    fullName: namespace.title,
+    desc: namespaceDescriptions[namespace.title.toLowerCase()],
+    keywords: keywords.join(', ')
+  };
+  const adoc = template(data) + indexPageLines.join('');
+  return adoc;
+};
+
+const generateLegacyIndexPages = (
+  indexPage: NavFile,
+  sortedTypes: Type[],
+  memberTemplate: HandlebarsTemplateDelegate,
+  structure: ExportStructure
+): PageOutput[] => {
+  const newNavPages = [] as PageOutput[];
+  const descriptions = getDescriptionsFromTypes(sortedTypes);
+  indexPage.pages.forEach((namespace) =>
+    newNavPages.push({
+      type: 'adoc',
+      filename: BASE_PATH + '/api/' + namespace.path + '/index.adoc',
+      content: legacyIndexToAdoc(namespace, memberTemplate, descriptions, structure)
+    })
+  );
+  return newNavPages;
+};
+
+export {
+  compileTemplate,
+  getNavFile,
+  generateNavPages,
+  generateLegacyIndexPages,
+  getFilePath,
+  getJsonFilePath,
+  generateXref,
+  generateTypeXref
+};

--- a/src/templates/antora/util.ts
+++ b/src/templates/antora/util.ts
@@ -246,7 +246,7 @@ const generateLegacyIndexPages = (
   memberTemplate: HandlebarsTemplateDelegate,
   structure: ExportStructure
 ): PageOutput[] => {
-  const newNavPages = [] as PageOutput[];
+  const newNavPages: PageOutput[] = [];
   const descriptions = getDescriptionsFromTypes(sortedTypes);
   indexPage.pages.forEach((namespace) =>
     newNavPages.push({


### PR DESCRIPTION
Related Ticket: TINY-8747

Description of Changes:
* Added `structure` option with `legacy` value for nested folder output within antora template.
* PR attempt 2.

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] ~Tests have been added (if applicable)~
