### PR TITLE
DEVOPS-512: Bump waluigi to 6.0.1 to fix git issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 #!groovy
-@Library('waluigi@v6.0.0') _
+@Library('waluigi@v6.0.1') _
 
 beehiveFlowBuild()


### PR DESCRIPTION
Related Ticket: DEVOPS-512

Description of Changes:
* Bumped waluigi to 6.0.1 to fix issues with the GitHub known hosts not being populated correctly

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~
