### PR TITLE
TINY-9742: Fix amount of new lines in asciidoc converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.3.0 - 2022-08-23
-
 ### Added
 - New `structure` option for specifying `legacy` nested structure for antora docs.
+
+### Fixed
+- The `antora` template did not add enough newline characters when replacing <br> tags.
 
 ## 0.2.1 - 2022-04-29
 

--- a/src/templates/antora/antora.converter.ts
+++ b/src/templates/antora/antora.converter.ts
@@ -22,7 +22,7 @@ const escapeComments = (str: string): string =>
 
 // convert BRs found into asciidoc \n
 const encodeBR = (str: string): string =>
-  str.replace(/\s*<br\s*\/?>\s*/g, '\n');
+  str.replace(/\s*<br\s*\/?>\s*/g, '\n\n\n');
 
 // convert <em> into __italics__ asciidoc
 const encodeEM = (str: string): string =>


### PR DESCRIPTION
Related Ticket: TINY-9742

Description of Changes:
* Added extra newlines for <br> tag replacement in asciidoc converter.
* Asciidoc requires more newlines to display correctly

Pre-checks:
* [x] Changelog entry added
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~
